### PR TITLE
Only show first line of notes. Show full in Log Entries viewer

### DIFF
--- a/slickqaweb/static/resources/pages/result-list/result-list.html
+++ b/slickqaweb/static/resources/pages/result-list/result-list.html
@@ -102,7 +102,7 @@
         <div class="result-list-notes-part">
             <div ng-repeat="note in getResultNotes(result)" class="result-note">
                 <span class="result-note-timestamp" ng-bind="note.entryTime |date:'medium'"></span>
-                <span class="result-note-message" ng-bind="note.message"></span>
+                <span class="result-note-message" ng-bind="note.message.split('\n')[0]"></span>
                 <a href="{{note.exceptionMessage}}" class="result-note-link" ng-show="note.exceptionMessage" ng-bind="note.exceptionMessage"></a>
             </div>
         </div>

--- a/slickqaweb/static/resources/pages/testruns/testrun-summary.html
+++ b/slickqaweb/static/resources/pages/testruns/testrun-summary.html
@@ -197,7 +197,7 @@
         <div class="result-list-notes-part">
             <div ng-repeat="note in getResultNotes(result)" class="result-note">
                 <span class="result-note-timestamp" ng-bind="note.entryTime |date:'medium'"></span>
-                <span class="result-note-message" ng-bind="note.message"></span>
+                <span class="result-note-message" ng-bind="note.message.split('\n')[0]"></span>
                 <a href="{{note.exceptionMessage}}" class="result-note-link" ng-show="note.exceptionMessage" ng-bind="note.exceptionMessage"></a>
             </div>
         </div>


### PR DESCRIPTION
This is the same logic that's used in `getAbbreviatedReason()` here: 

https://github.com/slickqa/slickqaweb/blob/master/slickqaweb/static/resources/pages/testruns/testruns.js#L316-L323

I'm attaching the reason for the failure to the reschedule message. Like so:

![screen shot 2018-04-20 at 3 07 55 pm](https://user-images.githubusercontent.com/10365264/39073896-a99e7c2e-44ac-11e8-93bd-09c386d0b356.png)
