### PR TITLE
Add navigation for TPS report

### DIFF
--- a/slickqaweb/static/resources/pages/buildreport/buildreport.js
+++ b/slickqaweb/static/resources/pages/buildreport/buildreport.js
@@ -105,6 +105,7 @@ angular.module('slickApp')
                 $scope.testrungroup = buildreport;
                 $scope.estimatedTimeRemaining = "";
                 $scope.buildRunTime = "";
+                $scope.isBuildReport = false;
                 var testrungroup = buildreport;
                 if (buildreport.hasOwnProperty('name')) {
                     nav.setTitle(buildreport.name);
@@ -115,6 +116,7 @@ angular.module('slickApp')
                         }
                     }
                     $scope.estimatedTimeRemaining = getEstimatedTimeRemaining(buildreport, 'build');
+                    $scope.isBuildReport = true;
                     let createdTime = buildreport.testruns[0].dateCreated;
                     if (finishedRunTimes.length === buildreport.testruns.length || $scope.estimatedTimeRemaining === "") {
                         $scope.buildRunTime = finishedRunTimes.length !== 0 ? getDurationString(Math.max(...finishedRunTimes) - createdTime, true) : "";

--- a/slickqaweb/static/resources/pages/testrungroup/view-testrungroup.html
+++ b/slickqaweb/static/resources/pages/testrungroup/view-testrungroup.html
@@ -40,7 +40,10 @@
                     <div class="testruns-list-results-column"><div class="testruns-list-results-container"><slick-testrun-stats testrun="testrun"></slick-testrun-stats><slick-testrun-statusbar summary="testrun.summary" size="normal"></slick-testrun-statusbar></div></div>
                     <div class="testruns-list-environment-column" ng-bind="testrun.config.name"></div>
                     <div class="testruns-list-build-column">{{testrun.release.name}} Build {{ testrun.build.name }}</div>
-                    <div class="testruns-list-created-column" ng-bind="testrun.dateCreated | date:'medium'"></div>
+                    <div class="testruns-list-created-column">
+                        <div class="testruns-list-created-column" ng-bind="testrun.dateCreated | date:'medium'"></div>
+                        <a ng-show="isBuildReport" class="button" href="tps-report/{{ testrun.project.name }}/{{ testrun.release.name }}/{{ testrun.testplan.name }}">TPS Report</a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/slickqaweb/static/resources/pages/testruns/testrun-summary.html
+++ b/slickqaweb/static/resources/pages/testruns/testrun-summary.html
@@ -74,9 +74,6 @@
                     </div>
                 </div>
                 <div class="testrun-summary-metadata">
-                    <div class="testrun-summary-metadata-row testrun-summary-metadata-row-build" ng-show="testrun.build.name">
-                        <a class="testrun-summary-metadata-value button" href="{{ goToBuildReportButton.href }}">{{ goToBuildReportButton.name }}</a>
-                    </div>
                     <div class="testrun-summary-metadata-row testrun-summary-metadata-row-project" ng-show="testrun.project">
                         <div class="testrun-summary-metadata-key">Project: </div>
                         <div class="testrun-summary-metadata-value" ng-bind="testrun.project.name"></div>
@@ -132,6 +129,12 @@
                         <div class="testrun-summary-metadata-value">
                             <a ng-repeat="link in testrun.links" href="{{link.url}}" target="_blank">{{link.name}}</a>
                         </div>
+                    </div>
+                    <div class="testrun-summary-metadata-row" ng-show="testrun.build.name">
+                        <a class="testrun-summary-metadata-value button" href="{{ goToBuildReportButton.href }}">{{ goToBuildReportButton.name }}</a>
+                    </div>
+                    <div class="testrun-summary-metadata-row" ng-show="testrun.release.name">
+                        <a class="testrun-summary-metadata-value button" href="{{ goToTPSReportButton.href }}">{{ goToTPSReportButton.name }}</a>
                     </div>
                     <div ng-show="testrun.info">
                         <pre ng-bind="testrun.info"></pre>

--- a/slickqaweb/static/resources/pages/testruns/testruns.js
+++ b/slickqaweb/static/resources/pages/testruns/testruns.js
@@ -257,7 +257,11 @@ angular.module('slickApp')
                 nav.setTitle("Summary: " + $scope.getDisplayName(testrun));
                 $scope.goToBuildReportButton = {
                     href: `build-report/${testrun.project.name}/${testrun.release.name}/${testrun.build.name}`,
-                    name: "Go to Build Report"
+                    name: "Build Report"
+                };
+                $scope.goToTPSReportButton = {
+                    href: `tps-report/${testrun.project.name}/${testrun.release.name}/${testrun.testplan.name}`,
+                    name: "TPS Report"
                 };
                 $scope.estimatedTimeRemaining = testrun.state !== 'FINISHED' ? getEstimatedTimeRemaining(testrun, 'testrun') : "";
 

--- a/slickqaweb/static/resources/pages/testruns/testruns.less
+++ b/slickqaweb/static/resources/pages/testruns/testruns.less
@@ -248,6 +248,11 @@
   font-weight: bold;
 }
 
+.testrun-summary-metadata-value.button {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
 .testrun-summary-metadata-row-project,
 .testrun-summary-metadata-row-release,
 .testrun-summary-metadata-row-build {

--- a/slickqaweb/static/resources/pages/tps/tps.js
+++ b/slickqaweb/static/resources/pages/tps/tps.js
@@ -51,9 +51,9 @@ angular.module('slickApp')
                         return testrun.dateCreated;
                     });
                     _.each(testrungroup.groupSummary.statusListOrdered, function (status) {
-                        var color = getStyle(status.replace("_", "") + "-element", "color");
+                        var color = getStyle(replaceOnStatus(status, "") + "-element", "color");
                         $scope.serialChartOptions.colors.push(color);
-                        $scope.serialData.addColumn('number', status.replace("_", " "))
+                        $scope.serialData.addColumn('number', replaceOnStatus(status, " "))
                     });
                     _.each(testrungroup.testruns, function (testrun) {
                         var row = [new Date(testrun.dateCreated)];

--- a/slickqaweb/static/scripts.js
+++ b/slickqaweb/static/scripts.js
@@ -1633,7 +1633,11 @@ angular.module('slickApp')
                 nav.setTitle("Summary: " + $scope.getDisplayName(testrun));
                 $scope.goToBuildReportButton = {
                     href: `build-report/${testrun.project.name}/${testrun.release.name}/${testrun.build.name}`,
-                    name: "Go to Build Report"
+                    name: "Build Report"
+                };
+                $scope.goToTPSReportButton = {
+                    href: `tps-report/${testrun.project.name}/${testrun.release.name}/${testrun.testplan.name}`,
+                    name: "TPS Report"
                 };
                 $scope.estimatedTimeRemaining = testrun.state !== 'FINISHED' ? getEstimatedTimeRemaining(testrun, 'testrun') : "";
 
@@ -2550,6 +2554,7 @@ angular.module('slickApp')
                 $scope.testrungroup = buildreport;
                 $scope.estimatedTimeRemaining = "";
                 $scope.buildRunTime = "";
+                $scope.isBuildReport = false;
                 var testrungroup = buildreport;
                 if (buildreport.hasOwnProperty('name')) {
                     nav.setTitle(buildreport.name);
@@ -2560,6 +2565,7 @@ angular.module('slickApp')
                         }
                     }
                     $scope.estimatedTimeRemaining = getEstimatedTimeRemaining(buildreport, 'build');
+                    $scope.isBuildReport = true;
                     let createdTime = buildreport.testruns[0].dateCreated;
                     if (finishedRunTimes.length === buildreport.testruns.length || $scope.estimatedTimeRemaining === "") {
                         $scope.buildRunTime = finishedRunTimes.length !== 0 ? getDurationString(Math.max(...finishedRunTimes) - createdTime, true) : "";
@@ -2680,9 +2686,9 @@ angular.module('slickApp')
                         return testrun.dateCreated;
                     });
                     _.each(testrungroup.groupSummary.statusListOrdered, function (status) {
-                        var color = getStyle(status.replace("_", "") + "-element", "color");
+                        var color = getStyle(replaceOnStatus(status, "") + "-element", "color");
                         $scope.serialChartOptions.colors.push(color);
-                        $scope.serialData.addColumn('number', status.replace("_", " "))
+                        $scope.serialData.addColumn('number', replaceOnStatus(status, " "))
                     });
                     _.each(testrungroup.testruns, function (testrun) {
                         var row = [new Date(testrun.dateCreated)];

--- a/slickqaweb/static/style.css
+++ b/slickqaweb/static/style.css
@@ -4394,6 +4394,10 @@ div.multi-project-dashboard-statusbar {
   width: 1.8in;
   font-weight: bold;
 }
+.testrun-summary-metadata-value.button {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
 .testrun-summary-metadata-row-project,
 .testrun-summary-metadata-row-release,
 .testrun-summary-metadata-row-build {


### PR DESCRIPTION
 - Add navigation for TPS report to build report testrun list items and testrun report

Updated `replace` used to strip underscores for TPS graph to use global function `replaceOnStatus` (wasn't handling multiple underscores)
Also made links on testrun report less IN YOUR FACE.
TPS Report links do not show on the testrun list items within the TPS Report itself via a `isBuildReport` boolean check.

`Build Report`
![screen shot 2018-06-22 at 5 14 28 pm](https://user-images.githubusercontent.com/10365264/41802698-f4fd60ee-763f-11e8-981b-d9be067dd715.png)

`TestRun Report`
![screen shot 2018-06-22 at 5 14 43 pm](https://user-images.githubusercontent.com/10365264/41802701-fb3c3566-763f-11e8-8bb2-0251cc33ff99.png)


